### PR TITLE
Highlight reference to further examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ exec(
 )
 ```
 
-For a complete demo and various examples,
-see [`GrpcExample` in test](src/test/scala/com/github/phisgr/example/GrpcExample.scala).
+__For a complete demo and various examples (including the proper syntax to include a variable from a feeder),
+see [`GrpcExample` in test](src/test/scala/com/github/phisgr/example/GrpcExample.scala).__
 
 ### Dynamic Payload
 There are helper methods in `gatling-grpc` for


### PR DESCRIPTION
We overlooked the line 50 and spent a lot of time trying to inject variables from a feeder the "http-gatling way" (without lens and with standard Gatling EL syntax, which didn't work).

Highlighting the link to the detailed examples could help other developers avoid our mistake.