### PR TITLE
Set correct startTimestamp

### DIFF
--- a/src/main/scala/com/github/phisgr/gatling/grpc/stream/StreamCall.scala
+++ b/src/main/scala/com/github/phisgr/gatling/grpc/stream/StreamCall.scala
@@ -160,7 +160,7 @@ abstract class StreamCall[Req, Res, State >: ServerStreamState](
       streamSession.scenario,
       streamSession.groups,
       requestName = requestName,
-      startTimestamp = completeTimeMillis,
+      startTimestamp = callStartTime,
       endTimestamp = completeTimeMillis,
       status = status,
       responseCode = Some(grpcStatus.getCode.toString),


### PR DESCRIPTION
Setting the correct startTimestamp to have all the metrics (percentiles, avg, etc) in stream mode.