### PR TITLE
Add TimestampsExtractor for Batched Response Handling

### DIFF
--- a/src/main/scala/com/github/phisgr/gatling/grpc/action/stream.scala
+++ b/src/main/scala/com/github/phisgr/gatling/grpc/action/stream.scala
@@ -5,7 +5,7 @@ import com.github.phisgr.gatling.grpc.check.GrpcResponse.GrpcStreamEnd
 import com.github.phisgr.gatling.grpc.check.{StatusExtract, StreamCheck}
 import com.github.phisgr.gatling.grpc.request.{Call, CallDefinition}
 import com.github.phisgr.gatling.grpc.stream.StreamCall.StreamEndLog
-import com.github.phisgr.gatling.grpc.stream.{EventExtractor, TimestampExtractor}
+import com.github.phisgr.gatling.grpc.stream.{EventExtractor, TimestampExtractor, TimestampsExtractor}
 import io.gatling.commons.validation.Validation
 import io.gatling.core.session.{Expression, Session}
 import io.gatling.core.structure.ScenarioContext
@@ -33,6 +33,8 @@ trait StreamStartBuilder[Self, Req, Res] extends CallDefinition[Self, Req, Res] 
 
   def eventExtractor(extractor: EventExtractor[Res]): Self
   def timestampExtractor(extractor: TimestampExtractor[Res]): Self =
+    eventExtractor(extractor)
+  def timestampsExtractor(extractor: TimestampsExtractor[Res]): Self =
     eventExtractor(extractor)
   def sessionCombiner(sessionCombiner: SessionCombiner): Self
 }

--- a/src/main/scala/com/github/phisgr/gatling/grpc/stream/TimestampsExtractor.scala
+++ b/src/main/scala/com/github/phisgr/gatling/grpc/stream/TimestampsExtractor.scala
@@ -16,7 +16,7 @@ trait TimestampsExtractor[-Res] extends EventExtractor[Res] {
    * @return A list of timestamps extracted from the response, or [[TimestampsExtractor.IgnoreMessage]]
    *         if the message should be ignored.
    */
-  def extractTimestamp(session: Session, message: Res, streamStartTime: Long): List[Long]
+  def extractTimestamps(session: Session, message: Res, streamStartTime: Long): List[Long]
 
   final override def writeEvents(
     session: Session,
@@ -29,7 +29,7 @@ trait TimestampsExtractor[-Res] extends EventExtractor[Res] {
     status: Status,
     errorMessage: Option[String]
   ): Unit = {
-    val extractedTimes = extractTimestamp(session, message, streamStartTime)
+    val extractedTimes = extractTimestamps(session, message, streamStartTime)
 
     if (extractedTimes == TimestampsExtractor.IgnoreMessage) {
       logger.trace(s"Ignored message\n${toProtoString(message)}")

--- a/src/main/scala/com/github/phisgr/gatling/grpc/stream/TimestampsExtractor.scala
+++ b/src/main/scala/com/github/phisgr/gatling/grpc/stream/TimestampsExtractor.scala
@@ -1,0 +1,58 @@
+package com.github.phisgr.gatling.grpc.stream
+
+import com.github.phisgr.gatling.grpc.util.toProtoString
+import com.typesafe.scalalogging.Logger
+import io.gatling.commons.stats.Status
+import io.gatling.core.session.Session
+import io.gatling.core.stats.StatsEngine
+
+trait TimestampsExtractor[-Res] extends EventExtractor[Res] {
+   /**
+   * Extracts timestamps from the given response message in the context of the streaming session.
+   *
+   * @param session         The streaming session.
+   * @param message         The response message.
+   * @param streamStartTime The start time of the entire streaming session.
+   * @return A list of timestamps extracted from the response, or [[TimestampsExtractor.IgnoreMessage]]
+   *         if the message should be ignored.
+   */
+  def extractTimestamp(session: Session, message: Res, streamStartTime: Long): List[Long]
+
+  final override def writeEvents(
+    session: Session,
+    streamStartTime: Long,
+    requestName: String,
+    message: Res,
+    receiveTime: Long,
+    statsEngine: StatsEngine,
+    logger: Logger,
+    status: Status,
+    errorMessage: Option[String]
+  ): Unit = {
+    val extractedTimes = extractTimestamp(session, message, streamStartTime)
+
+    if (extractedTimes == TimestampsExtractor.IgnoreMessage) {
+      logger.trace(s"Ignored message\n${toProtoString(message)}")
+    } else {
+      extractedTimes.foreach { extractedTime => 
+        statsEngine.logResponse(
+          session.scenario,
+          session.groups,
+          requestName = requestName,
+          startTimestamp = extractedTime,
+          endTimestamp = receiveTime,
+          status = status,
+          responseCode = None,
+          message = errorMessage
+        )
+      }
+    }
+  }
+}
+
+object TimestampsExtractor {
+  /** Return this sentinel value and the message will not be logged */
+  final val IgnoreMessage = Nil
+
+  final val Ignore: TimestampsExtractor[Any] = (_, _, _) => IgnoreMessage
+}


### PR DESCRIPTION
 In streaming applications, it's a common practice to batch responses to improve performance. However, the current implementation of gatling-grpc lacks a mechanism to extract multiple timestamps from a single batched response. This limitation inhibits accurate performance logging in scenarios where multiple timestamps are relevant within a single response.
  This pull request introduces the `TimestampsExtractor` trait, extending the existing `EventExtractor`, to facilitate the extraction of multiple timestamps from batched responses. The `extractTimestamps` method within this trait returns a list of timestamps, allowing for more comprehensive timestamp handling.
   This enhancement enables users to accurately capture and log multiple timestamps within a single response, accommodating the common practice of batching responses in streaming applications.